### PR TITLE
64 resolve cran test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ inst/doc
 .env
 docs
 /.quarto/
+.specstory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Imports:
     dplyr (>= 1.0.0),
     purrr (>= 1.0.0),
     tidyr (>= 1.0.0),
-    rlang (>= 1.0.0)
+    rlang (>= 1.0.0),
+    mime
 Suggests: 
     curl,
     jsonlite,

--- a/R/ids_bulk.R
+++ b/R/ids_bulk.R
@@ -85,8 +85,19 @@ get_response_headers <- function(file_url) {
 #' @noRd
 #'
 download_bulk_file <- function(file_url, file_path, timeout, warn_size, quiet) {
-
+  # Error on response mime type mismatch (esp. HTML instead of Excel)
   response_headers <- get_response_headers(file_url)
+  mime_type <- mime::guess_type(file_path)
+
+  if (response_headers$`content-type` != mime_type) {
+    cli::cli_abort(
+      paste0(
+        "Request returned an invalid file type. ",
+        "Please check the URL and try again."
+      )
+    )
+  }
+
   size_mb <- as.numeric(response_headers$`content-length`) / 1024^2
   formatted_size <- format(round(size_mb, 1), nsmall = 1) # nolint
 


### PR DESCRIPTION
- `ids_bulk` now validates by checking the MIME type in the response header to make sure it matches expectation before trying to download the file
- Tests in `test_ids_bulk.R` now use mock response headers to pass this validation check
- We're no longer actually making an actual API request to "invalid-url.com"