### PR TITLE
Fix `ids_bulk()` fails due to breaking changes on datacatalog.worldbank.org

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@ _pkgdown.yml
 ^docs$
 ^pkgdown$
 ^.specstory$
+CLAUDE.md

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     rlang (>= 1.0.0)
 Suggests: 
     curl,
+    jsonlite,
     tibble,
     quarto,
     readxl (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wbids
 Title: Seamless Access to World Bank International Debt Statistics (IDS)
-Version: 1.0.0.9000
+Version: 1.0.0.9001
 Authors@R: 
     c(person("Teal", "Emery", , "lte@tealinsights.com", role = c("aut", "cre")),
       person("Teal Insights", role = c("cph")),
@@ -26,11 +26,9 @@ Imports:
     dplyr (>= 1.0.0),
     purrr (>= 1.0.0),
     tidyr (>= 1.0.0),
-    rlang (>= 1.0.0),
-    mime
+    rlang (>= 1.0.0)
 Suggests: 
     curl,
-    jsonlite,
     tibble,
     quarto,
     readxl (>= 1.0.0),

--- a/R/ids_bulk_files.R
+++ b/R/ids_bulk_files.R
@@ -30,7 +30,7 @@ ids_bulk_files <- function() {
     ) |>
     select(file_name = "name", file_url = "url", "last_updated_date") |>
     mutate(
-      file_url = sub("\\?.*$", "", file_url),
+      file_url = sub("\\?.*$", "", .data$file_url),
       last_updated_date = as.Date(.data$last_updated_date)
     ) |>
     arrange("file_url")

--- a/R/ids_bulk_files.R
+++ b/R/ids_bulk_files.R
@@ -18,19 +18,22 @@
 #' ids_bulk_files()
 #'
 ids_bulk_files <- function() {
-
   ids_meta <- read_bulk_info()
 
   bulk_files <- ids_meta$resources |>
     as_tibble() |>
     select("name", "distribution", "last_updated_date") |>
     tidyr::unnest("distribution") |>
-    filter(grepl("Bulk Download File - Debtor Countries:", .data$name) &
-             !is.na(.data$url)) |>
+    filter(
+      grepl("Bulk Download File - Debtor Countries:", .data$name) &
+        !is.na(.data$url)
+    ) |>
     select(file_name = "name", file_url = "url", "last_updated_date") |>
-    mutate(last_updated_date = as.Date(.data$last_updated_date)) |>
-    arrange("file_name")
+    mutate(
+      file_url = sub("\\?.*$", "", file_url),
+      last_updated_date = as.Date(.data$last_updated_date)
+    ) |>
+    arrange("file_url")
 
   bulk_files
-
 }

--- a/R/ids_bulk_series.R
+++ b/R/ids_bulk_series.R
@@ -23,7 +23,6 @@
 #' ids_bulk_series()
 #'
 ids_bulk_series <- function() {
-
   ids_meta <- read_bulk_info()
 
   bulk_series <- ids_meta$indicators |>
@@ -38,5 +37,4 @@ ids_bulk_series <- function() {
     left_join(api_series, join_by("series_id"))
 
   bulk_series
-
 }

--- a/R/read_bulk_info.R
+++ b/R/read_bulk_info.R
@@ -8,7 +8,8 @@
 #'
 read_bulk_info <- function() {
   rlang::check_installed(
-    "jsonlite", reason = "to retrieve available series via bulk download."
+    "jsonlite",
+    reason = "to retrieve available series via bulk download."
   )
 
   jsonlite::fromJSON(

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.4.2",
+    "Version": "4.4.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -31,14 +31,14 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.6.3",
+      "Version": "3.6.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "b21916dd77a27642b447374a5d30ecf3"
+      "Hash": "491c34d3d9dd0d2fe13d9f278bb90795"
     },
     "cpp11": {
       "Package": "cpp11",
@@ -52,13 +52,13 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "6.0.1",
+      "Version": "6.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "e8ba62486230951fcd2b881c5be23f96"
+      "Hash": "e4f9e10b18f453a1b7eaf38247dad4fe"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -119,7 +119,7 @@
     },
     "httr2": {
       "Package": "httr2",
-      "Version": "1.0.7",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -136,7 +136,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "5a76da345ed4f3e6430517e08441edaf"
+      "Hash": "ade531519694081d91036b509eb30594"
     },
     "lifecycle": {
       "Package": "lifecycle",
@@ -160,16 +160,6 @@
         "R"
       ],
       "Hash": "7ce2733a9826b3aeb1775d56fd305472"
-    },
-    "mime": {
-      "Package": "mime",
-      "Version": "0.12",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "tools"
-      ],
-      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
     },
     "openssl": {
       "Package": "openssl",
@@ -210,7 +200,7 @@
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.0.2",
+      "Version": "1.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -221,7 +211,7 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
+      "Hash": "cc8b5d43f90551fa6df0a6be5d640a4f"
     },
     "rappdirs": {
       "Package": "rappdirs",
@@ -245,14 +235,14 @@
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.1.4",
+      "Version": "1.1.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "3eec01f8b1dee337674b2e34ab1f9bc1"
+      "Hash": "724dcc1490cd7071ee75ca2994a5446e"
     },
     "stringi": {
       "Package": "stringi",

--- a/tests/testthat/test-ids_bulk.R
+++ b/tests/testthat/test-ids_bulk.R
@@ -82,7 +82,7 @@ test_that("ids_bulk handles message parameter correctly", {
 
   test_url <- paste0(
     "https://datacatalogfiles.worldbank.org/ddh-published/0038015/DR0092201/",
-    "A_D.xlsx?versionId=2024-12-04T18:30:10.8890786Z"
+    "A_D.xlsx"
   )
 
   mock_data <- tibble::tibble(
@@ -170,7 +170,7 @@ test_that("ids_bulk handles warn_size parameter", {
 
   test_url <- paste0(
     "https://datacatalogfiles.worldbank.org/ddh-published/0038015/DR0092201/",
-    "A_D.xlsx?versionId=2024-12-04T18:30:10.8890786Z"
+    "A_D.xlsx"
   )
 
   local_mocked_bindings(
@@ -179,7 +179,7 @@ test_that("ids_bulk handles warn_size parameter", {
     check_interactive = function() FALSE
   )
 
-  expect_warning(
+  expect_message(
     download_bulk_file(
       test_url,
       tempfile(fileext = ".xlsx"),
@@ -222,7 +222,7 @@ test_that("download_bulk_file downloads files correctly", {
 
   test_url <- paste0(
     "https://datacatalogfiles.worldbank.org/ddh-published/0038015/DR0092201/",
-    "A_D.xlsx?versionId=2024-12-04T18:30:10.8890786Z"
+    "A_D.xlsx"
   )
   test_path <- tempfile(fileext = ".xlsx")
 
@@ -309,7 +309,7 @@ test_that("ids_bulk downloads and processes data correctly", {
 
   test_url <- paste0(
     "https://datacatalogfiles.worldbank.org/ddh-published/0038015/DR0092201/",
-    "A_D.xlsx?versionId=2024-10-08T01:35:39.3946879Z"
+    "A_D.xlsx"
   )
   test_path <- tempfile(fileext = ".xlsx")
 
@@ -376,7 +376,7 @@ test_that("warn_size warning is triggered & user prompt is handled correctly", {
 
   test_url <- paste0(
     "https://datacatalogfiles.worldbank.org/ddh-published/0038015/DR0092201/",
-    "A_D.xlsx?versionId=2024-12-04T18:30:10.8890786Z"
+    "A_D.xlsx"
   )
   temp_file <- tempfile(fileext = ".xlsx")
 

--- a/tests/testthat/test-ids_bulk.R
+++ b/tests/testthat/test-ids_bulk.R
@@ -26,7 +26,7 @@ test_that("ids_bulk handles custom file paths", {
     },
     get_response_headers = function(...) {
       list(
-        `content-type` = mime::guess_type(temp_path),
+        `content-type` = "application/octet-stream",
         `content-length` = 1000
       )
     }
@@ -39,7 +39,10 @@ test_that("ids_bulk handles custom file paths", {
   )
 
   result <- ids_bulk(
-    test_url, file_path = temp_path, quiet = TRUE, warn_size = FALSE
+    test_url,
+    file_path = temp_path,
+    quiet = TRUE,
+    warn_size = FALSE
   )
 
   expect_false(file.exists(temp_path))
@@ -134,15 +137,20 @@ test_that("ids_bulk handles timeout parameter correctly", {
       current_timeout <- getOption("timeout")
       # Verify the timeout option was set correctly
       if (current_timeout == 1) {
-        stop(paste0(
-          "Download timed out after ", current_timeout, " seconds"
-        ), call. = FALSE)
+        stop(
+          paste0(
+            "Download timed out after ",
+            current_timeout,
+            " seconds"
+          ),
+          call. = FALSE
+        )
       }
       stop("Unexpected timeout value", call. = FALSE)
     },
     get_response_headers = function(...) {
       list(
-        `content-type` = mime::guess_type("file.xlsx"),
+        `content-type` = "application/octet-stream",
         `content-length` = "1000"
       )
     }
@@ -173,14 +181,22 @@ test_that("ids_bulk handles warn_size parameter", {
 
   expect_warning(
     download_bulk_file(
-      test_url, tempfile(fileext = ".xlsx"), 60, warn_size = TRUE, quiet = TRUE
+      test_url,
+      tempfile(fileext = ".xlsx"),
+      60,
+      warn_size = TRUE,
+      quiet = TRUE
     ),
     "may take several minutes to download"
   )
 
   expect_no_warning(
     download_bulk_file(
-      test_url, tempfile(fileext = ".xlsx"), 60, warn_size = FALSE, quiet = TRUE
+      test_url,
+      tempfile(fileext = ".xlsx"),
+      60,
+      warn_size = FALSE,
+      quiet = TRUE
     )
   )
 })
@@ -266,7 +282,8 @@ test_that("process_bulk_data processes data correctly", {
   expect_equal(result$geography_id, expected_country_codes)
 
   expected_counterpart_codes <- rep(
-    test_data$`Counterpart-Area Code`, each = 17
+    test_data$`Counterpart-Area Code`,
+    each = 17
   )
   expect_equal(result$counterpart_id, expected_counterpart_codes)
 
@@ -305,18 +322,29 @@ test_that("ids_bulk downloads and processes data correctly", {
   )
 
   result <- ids_bulk(
-    test_url, file_path = test_path, quiet = TRUE, warn_size = FALSE
+    test_url,
+    file_path = test_path,
+    quiet = TRUE,
+    warn_size = FALSE
   )
 
   expect_s3_class(result, "tbl_df")
 
   expected_columns <- c(
-    "geography_id", "series_id", "counterpart_id", "year", "value"
+    "geography_id",
+    "series_id",
+    "counterpart_id",
+    "year",
+    "value"
   )
   expect_equal(colnames(result), expected_columns)
 
   expected_types <- c(
-    "character", "character", "character", "integer", "numeric"
+    "character",
+    "character",
+    "character",
+    "integer",
+    "numeric"
   )
   expect_true(all(lapply(result, class) == expected_types))
 })
@@ -355,7 +383,7 @@ test_that("warn_size warning is triggered & user prompt is handled correctly", {
   with_mocked_bindings(
     get_response_headers = function(...) {
       list(
-        `content-type` = mime::guess_type(temp_file),
+        `content-type` = "application/octet-stream",
         `content-length` = 150 * 1024^2
       )
     },
@@ -365,8 +393,11 @@ test_that("warn_size warning is triggered & user prompt is handled correctly", {
       expect_error(
         expect_warning(
           download_bulk_file(
-            test_url, temp_file,
-            timeout = 30, warn_size = TRUE, quiet = TRUE
+            test_url,
+            temp_file,
+            timeout = 30,
+            warn_size = TRUE,
+            quiet = TRUE
           ),
           regexp = "may take several minutes to download."
         ),


### PR DESCRIPTION
This PR includes:
- Remove url parameters from file_url in `ids_bulk_files()`
- Update header fetching without downloading the file (triggered by new content type)
- Replace mime type guessing with fixed content type "application/octet-stream" (a common default for data files afaik)
- Remove mime import
- Some minor automatic code formatting due to automatic use of Air formatter (once PR is approved, I'll also reformat other files)
- Switch to cli_alert_warning() for file size warning because cli_warn() was not shown due to the prompt

I'm not sure about read performance in the past, but a single file already feels like forever until it is read in.